### PR TITLE
Add release-freeze automation, migration guide, and backlog/TODO docs

### DIFF
--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -1,0 +1,31 @@
+name: Release Freeze Automation
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  freeze-and-next:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run freeze automation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/release_freeze.sh

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,102 @@
+# MIGRATION.md — v0 → Próxima Geração fw.webex
+
+## 1) Propósito
+
+> Execução operacional do congelamento: ver `V0_FREEZE.md`.
+
+Este documento descreve a migração da linha **v0 (congelada)** para a **nova geração** do fw.webex.
+
+- v0: baseline estável, manutenção corretiva/crítica.
+- Próxima geração: evolução arquitetural com possível breaking change.
+
+---
+
+## 2) Princípios da Migração
+
+1. Migração orientada por etapas (não big-bang obrigatório).
+2. Sem garantia de compatibilidade automática completa.
+3. Toda mudança relevante deve ter exemplo e documentação de uso.
+4. Recursos antigos podem ser deprecados com aviso prévio.
+
+---
+
+## 3) Escopos Iniciais de Mudança
+
+## 3.1 Inicializador de DOM configurável
+
+Novo contrato alvo:
+- `FWWebEx.init(config)`
+- `FWWebEx.ready(fn)`
+- hooks de ciclo de vida (ex.: `beforeInit`, `afterInit`, `onError`)
+
+Impacto esperado:
+- substituição/organização de pontos de bootstrap implícitos;
+- maior previsibilidade de inicialização por página/componente.
+
+## 3.2 Externalização de JavaScript
+
+Mudança alvo:
+- reduzir JS inline;
+- separar core e features em módulos carregáveis.
+
+Impacto esperado:
+- melhor manutenção e cache;
+- maior controle de carregamento por contexto.
+
+## 3.3 Modelo Plugável
+
+Mudança alvo:
+- registrar features/plugins com contrato mínimo (nome, versão, init, dependências).
+
+Impacto esperado:
+- desacoplamento entre core e extensões;
+- evolução incremental com menor atrito.
+
+---
+
+## 4) Guia de Migração por Fases
+
+### Fase A — Preparação
+- Identificar pontos de entrada v0 usados no projeto.
+- Mapear dependências JS inline e componentes críticos.
+
+### Fase B — Bootstrap Novo
+- Introduzir `FWWebEx.init(config)` no app.
+- Migrar inicialização principal para hooks explícitos.
+
+### Fase C — Plugins
+- Migrar uma feature piloto (datatable) para registro plugável.
+- Validar carregamento e fallback em ambiente de teste.
+
+### Fase D — Consolidação
+- Atualizar exemplos, testes e READMEs.
+- Remover dependências legadas selecionadas.
+
+---
+
+## 5) Checklist de Migração
+
+- [ ] Bootstrap novo aplicado no projeto.
+- [ ] JS inline crítico externalizado.
+- [ ] Plugin piloto ativo e validado.
+- [ ] Exemplos atualizados.
+- [ ] Testes essenciais executados.
+- [ ] Impactos documentados.
+
+---
+
+## 6) Convenção de Versionamento sugerida
+
+- v0.x.x: manutenção da linha congelada.
+- v1.0.0-alpha.N: maturação da nova geração.
+- v1.0.0-beta/rc: estabilização.
+- v1.0.0: release geral.
+
+---
+
+## 7) Observações
+
+Este guia será atualizado a cada sprint com:
+- mudanças introduzidas;
+- decisões de depreciação;
+- ajustes de fluxo de migração.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,130 @@
+# TODO.md — fw.webex (Próxima Geração)
+
+> **Status da linha atual:** v0 congelada (manutenção apenas corretiva/crítica)
+>  
+> **Nova linha evolutiva:** próxima geração (sem compromisso de retrocompatibilidade com v0)
+>  
+> **Data de início:** 2026-05-24
+
+---
+
+## 1) Visão da Geração
+
+Esta geração inicia uma nova arquitetura do fw.webex com foco em:
+- inicializador de DOM configurável;
+- externalização de JavaScript;
+- modelo plugável para recursos e integrações;
+- fechamento orientado a prioridade dos TODOs legados críticos.
+
+Fora de escopo imediato:
+- migração automática completa de projetos v0;
+- compatibilidade total e transparente entre v0 e nova geração.
+
+---
+
+## 2) Diretriz de Compatibilidade
+
+- A versão **v0 está congelada** como baseline estável.
+- A nova geração pode introduzir **breaking changes planejados**.
+- A migração será tratada por documentação e guias (`MIGRATION.md`), não por camada de compatibilidade obrigatória.
+
+---
+
+## 3) Objetivos e Métricas
+
+### Objetivos
+- [ ] Definir API de bootstrap (`FWWebEx.init(config)`) e lifecycle.
+- [ ] Implementar arquitetura plugável mínima (registro + init de plugins).
+- [ ] Externalizar JS por módulos (core + features).
+- [ ] Resolver TODOs P0/P1 com exemplos obrigatórios.
+
+### Métricas
+- TODOs P0 resolvidos: `0/2`
+- TODOs P1 resolvidos: `0/2`
+- Exemplos novos publicados: `0/2`
+- Módulos migrados para modelo plugável: `0/1 (piloto)`
+
+---
+
+## 4) Backlog Priorizado
+
+Legenda:
+- Prioridade: P0 (crítico), P1 (alto), P2 (médio)
+- Status: TODO | IN_PROGRESS | BLOCKED | DONE
+
+| ID | Prioridade | Módulo | Item | Origem | Exemplo obrigatório | Status | Sprint |
+|---|---|---|---|---|---|---|---|
+| NX-000 | P0 | governança/release | Efetivar congelamento operacional da v0 (tag + branches + proteção) | `V0_FREEZE.md` | Não | TODO | S1 |
+| NX-001 | P0 | core/table | Implementar carregamento real via AJAX | `src/fw.webex/core/component/fw.webex.table.tlpp` | Sim | TODO | S2 |
+| NX-002 | P0 | contrib/datatable | Finalizar fluxo do datatable form e estabilizar uso | `src/fw.webex/contrib/fw.webex.datatable/fw.webex.datatable.form.tlpp` | Sim | TODO | S1 |
+| NX-003 | P1 | features/markdown | Revisar TODOs de plugins markdown | `src/fw.webex/contrib/fw.webex.features/features/fw.webex.feature.markdown.tlpp` | Sim | TODO | S3 |
+| NX-004 | P1 | tests/md | Corrigir cenário PageHeader/PageFooter | `src/fw.webex/tests/md/testemd.tlpp` | Não | TODO | S1 |
+| NX-005 | P0 | core/bootstrap | Criar inicializador de DOM configurável com hooks | Novo | Sim | TODO | S1 |
+| NX-006 | P0 | core/plugins | Definir registro e contrato mínimo de plugins | Novo | Sim | TODO | S2 |
+
+---
+
+## 5) Definition of Ready (DoR)
+
+Um item entra em sprint quando:
+- possui critério funcional objetivo;
+- impacto técnico foi mapeado (core, contrib, docs e testes);
+- há estratégia de teste local definida;
+- se alterar comportamento: existe plano de exemplo e documentação.
+
+## 6) Definition of Done (DoD)
+
+Um item só pode ser concluído quando:
+- [ ] Implementação finalizada.
+- [ ] Testes/checagens locais executados.
+- [ ] Documentação atualizada (README/changelog/TODO).
+- [ ] Exemplo criado/atualizado (quando aplicável).
+- [ ] Impacto de migração documentado em `MIGRATION.md`.
+
+---
+
+## 7) Plano de Sprint
+
+### Sprint 1 — Fundação e primeira entrega visível
+
+Objetivo: estabelecer a base arquitetural e concluir um TODO crítico com exemplo.
+
+Escopo:
+1. NX-005: inicializador de DOM configurável (`init`, `ready`, hooks principais).
+2. NX-002: concluir datatable form.
+3. NX-004: corrigir teste markdown de header/footer.
+4. Criar 2 exemplos para datatable (mínimo e realista).
+5. Atualizar documentação de uso da feature.
+
+Critério de aceite:
+- 100% dos itens P0 planejados da sprint concluídos;
+- exemplos executáveis adicionados;
+- testes da área alterada executados.
+
+### Sprint 2 — Plugabilidade e núcleo de tabela
+
+Objetivo: consolidar arquitetura plugável e resolver TODO crítico do core/table.
+
+Escopo:
+1. NX-006: registro e ciclo de vida de plugins (piloto).
+2. NX-001: carregamento AJAX real em tabela.
+3. Integração plugin piloto + datatable.
+4. Atualização de guia de migração para mudanças técnicas.
+
+### Sprint 3 — Features e qualidade
+
+Objetivo: reduzir dívida técnica de markdown e elevar robustez.
+
+Escopo:
+1. NX-003: TODOs de markdown.
+2. Ajustes de estilo/comportamento associados.
+3. Revisão final de exemplos e testes da feature.
+
+---
+
+## 8) Política de Evolução
+
+- v0 permanece disponível como referência estável.
+- Nova geração evolui com versionamento próprio.
+- Breaking changes devem ser documentados previamente.
+- Cada alteração estrutural relevante precisa de impacto descrito no `MIGRATION.md`.

--- a/V0_FREEZE.md
+++ b/V0_FREEZE.md
@@ -1,0 +1,38 @@
+# V0_FREEZE.md — Registro Oficial de Congelamento da Linha v0
+
+## Motivo do Congelamento
+
+A linha **v0** foi congelada para separar formalmente:
+- a manutenção corretiva da versão estável atual; e
+- a evolução arquitetural da próxima geração do fw.webex.
+
+Essa decisão evita mistura de escopo (manutenção vs. evolução), reduz risco de regressão em produção e melhora a governança de releases.
+
+## Escopo e Política da v0
+
+A partir do congelamento:
+- a v0 permanece como **baseline estável**;
+- são permitidas apenas correções críticas/corretivas;
+- novas features e refactors estruturais ficam restritos à nova geração.
+
+## Dados do Congelamento
+
+- **Data de referência:** 2026-05-24
+- **Tag da baseline v0:** `v0.0.0`
+- **Commit baseline (SHA):** `e7f31bf`
+- **Branch de manutenção v0:** `release/v0`
+- **Branch da nova geração:** `next`
+
+## Relação com a Nova Geração
+
+A evolução da próxima geração ocorre na branch `next`, guiada por:
+- `TODO.md` (backlog e plano de sprint);
+- `MIGRATION.md` (diretrizes e impactos de migração).
+
+## Status do Congelamento
+
+- [x] Baseline v0 definida
+- [x] Política de manutenção da v0 definida
+- [x] Estrutura de separação entre v0 e nova geração definida
+
+> Observação: este documento é um **registro de decisão e estado** do congelamento da v0.

--- a/scripts/release_freeze.sh
+++ b/scripts/release_freeze.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG_PREFIX="fw.webex-v"
+DEFAULT_VERSION="1.0.0"
+REPO="${GITHUB_REPOSITORY:-}"
+TOKEN="${GITHUB_TOKEN:-}"
+
+if [[ -z "$REPO" ]]; then
+  echo "GITHUB_REPOSITORY is required" >&2
+  exit 1
+fi
+
+git checkout main
+git pull origin main
+
+git fetch --tags --force
+latest_tag="$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | head -n1 || true)"
+
+if [[ -z "$latest_tag" ]]; then
+  new_version="$DEFAULT_VERSION"
+  prev_tag=""
+else
+  raw="${latest_tag#${TAG_PREFIX}}"
+  IFS='.' read -r major minor patch <<<"$raw"
+  patch=$((patch+1))
+  new_version="${major}.${minor}.${patch}"
+  prev_tag="$latest_tag"
+fi
+
+freeze_tag="${TAG_PREFIX}${new_version}"
+
+if git rev-parse -q --verify "refs/tags/${freeze_tag}" >/dev/null; then
+  echo "Tag ${freeze_tag} already exists. Nothing to do."
+  exit 0
+fi
+
+release_branch="release/${freeze_tag}"
+IFS='.' read -r nmajor nminor npatch <<<"$new_version"
+next_patch=$((npatch+1))
+next_version="${nmajor}.${nminor}.${next_patch}"
+develop_branch="develop/${TAG_PREFIX}${next_version}"
+
+# Changelog generation (since previous tag or all commits)
+range=""
+if [[ -n "${prev_tag}" ]]; then
+  range="${prev_tag}..HEAD"
+else
+  range="HEAD"
+fi
+
+commit_log="$(git log --pretty=format:'- %h %s' ${range} || true)"
+run_date="$(date -u +%Y-%m-%d)"
+
+if [[ -z "$commit_log" ]]; then
+  commit_log="- Sem commits relevantes para registrar"
+fi
+
+summary="- Congelamento automático após merge em main\n- Tag ${freeze_tag}\n- Branch de release ${release_branch}\n- Início de desenvolvimento em ${develop_branch}"
+
+tmp_file="$(mktemp)"
+{
+  echo "## ${freeze_tag} - ${run_date}"
+  echo
+  echo "### Resumo técnico"
+  echo -e "$summary"
+  echo
+  echo "### Commits"
+  echo "$commit_log"
+  echo
+  if [[ -f CHANGELOG.md ]]; then
+    cat CHANGELOG.md
+  fi
+} > "$tmp_file"
+mv "$tmp_file" CHANGELOG.md
+
+# Create freeze tag and release branch from main HEAD
+
+git tag -a "$freeze_tag" -m "Freeze fw.webex v${new_version}"
+git push origin "$freeze_tag"
+
+git branch "$release_branch" "$freeze_tag"
+git push origin "$release_branch"
+
+# Create next development branch from freeze tag
+if ! git show-ref --verify --quiet "refs/heads/${develop_branch}"; then
+  git branch "$develop_branch" "$freeze_tag"
+fi
+git push origin "$develop_branch"
+
+# Commit changelog on dedicated branch and open PR to main if changed
+if ! git diff --quiet -- CHANGELOG.md; then
+  pr_branch="chore/changelog-${freeze_tag}"
+  git checkout -B "$pr_branch" "$develop_branch"
+  git add CHANGELOG.md
+  git commit -m "docs(changelog): update for ${freeze_tag}"
+  git push -u origin "$pr_branch"
+
+  if [[ -n "$TOKEN" ]]; then
+    api_url="https://api.github.com/repos/${REPO}/pulls"
+    existing="$(curl -sS -H "Authorization: Bearer ${TOKEN}" -H "Accept: application/vnd.github+json" \
+      "${api_url}?state=open&head=$(echo "$REPO"|cut -d/ -f1):${pr_branch}&base=main")"
+    if [[ "$(echo "$existing" | rg -c '"html_url"' || true)" == "0" ]]; then
+      payload=$(cat <<JSON
+{"title":"docs(changelog): update for ${freeze_tag}","head":"${pr_branch}","base":"main","body":"Atualização automática do CHANGELOG para ${freeze_tag}."}
+JSON
+)
+      curl -sS -X POST "$api_url" -H "Authorization: Bearer ${TOKEN}" -H "Accept: application/vnd.github+json" -d "$payload" >/dev/null
+      echo "PR created for CHANGELOG update."
+    else
+      echo "PR already exists for ${pr_branch}."
+    fi
+  else
+    echo "GITHUB_TOKEN not provided; skipping PR creation."
+  fi
+else
+  echo "CHANGELOG.md unchanged; skipping PR creation."
+fi
+
+echo "Freeze flow completed: ${freeze_tag}"


### PR DESCRIPTION
### Motivation

- Introduce an automated, repeatable freeze-and-next workflow to formalize release freezes and start the next development line. 
- Capture migration strategy and backlog for the new generation of `fw.webex` to separate maintenance of the frozen v0 line from future-breaking evolution. 

### Description

- Add a GitHub Actions workflow `/.github/workflows/release-freeze.yml` that runs on pushes to `main` and on manual dispatch and invokes `./scripts/release_freeze.sh` with `GITHUB_TOKEN` and repository permissions to create tags, branches and PRs. 
- Add `scripts/release_freeze.sh`, a bash script that generates an incremented freeze tag (`fw.webex-v*`), creates a `release/*` branch for the tag, creates a `develop/*` branch for the next version, updates `CHANGELOG.md` with commits since the previous tag, pushes tags/branches, and opens a changelog PR when `GITHUB_TOKEN` is available. 
- Add documentation files `V0_FREEZE.md`, `MIGRATION.md`, and `TODO.md` to record the v0 freeze decision, provide a migration guide for the new generation (bootstrap API, plugin model, JS externalization), and track prioritized backlog and sprint plans. 

### Testing

- No automated tests were added or executed as part of this change; the new workflow will run on pushes to `main` and can be used to exercise the release freeze flow in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a137fc95e108330abb681a829142d34)