### PR TITLE
Fix Protheus.doc comment block formatting

### DIFF
--- a/src/fw.webex/core/tools/fw.webex.array.tools.tlpp
+++ b/src/fw.webex/core/tools/fw.webex.array.tools.tlpp
@@ -19,7 +19,7 @@ Released to Public Domain.
 namespace FWWebEx
 using namespace FWWebEx
 
-/*/{Protheus.doc} ArrayTools
+/* {Protheus.doc} ArrayTools
     Classe utilitaria para operacoes comuns com arrays em TLPP/ADVPL.
 
     Funcionalidades:
@@ -36,7 +36,7 @@ using namespace FWWebEx
     @type       Class
     @author     Marinaldo de Jesus
     @since      19/05/2026
-/*/
+*/
 class ArrayTools
 
     static method Merge(aArray1 as array, aArray2 as array, lSort as logical, bSort as codeblock, lClone as logical) as array
@@ -53,7 +53,7 @@ class ArrayTools
 
 endclass
 
-/*/{Protheus.doc} Merge
+/*{Protheus.doc} Merge
     Realiza merge de 2 arrays.
 
     @type       Static Method
@@ -67,7 +67,7 @@ endclass
     @example
         aResult:=ArrayTools():Merge({3,1},{2},.T.)
         aResult:=ArrayTools():Merge(aA,aB,.T.,{|x,y| x[1] < y[1]})
-/*/
+*/
 static method Merge(aArray1,aArray2,lSort,bSort,lClone) class ArrayTools
 
     local aMerged as array
@@ -109,7 +109,7 @@ static method Merge(aArray1,aArray2,lSort,bSort,lClone) class ArrayTools
 
 return(aMerged)
 
-/*/{Protheus.doc} MergeSorted
+/*{Protheus.doc} MergeSorted
     Realiza merge linear de 2 arrays previamente ordenados.
     Evita fazer ASort no final.
 
@@ -125,7 +125,7 @@ return(aMerged)
     @example
         aResult:=ArrayTools():MergeSorted({1,3,5},{2,4,6})
         aResult:=ArrayTools():MergeSorted(aA,aB,{|x,y| x[1] < y[1]})
-/*/
+*/
 static method MergeSorted(aArray1,aArray2,bLess,lClone) class ArrayTools
 
     local aMerged as array
@@ -189,7 +189,7 @@ static method MergeSorted(aArray1,aArray2,bLess,lClone) class ArrayTools
 
 return(aMerged)
 
-/*/{Protheus.doc} MergeUnique
+/*{Protheus.doc} MergeUnique
     Realiza merge de 2 arrays removendo duplicidades.
 
     @type       Static Method
@@ -203,7 +203,7 @@ return(aMerged)
     @example
         aResult:=ArrayTools():MergeUnique({1,2},{2,3})
         // Resultado: {1,2,3}
-/*/
+*/
 static method MergeUnique(aArray1,aArray2,bEqual,lSort,bSort) class ArrayTools
 
     local aMerged as array
@@ -236,7 +236,7 @@ static method MergeUnique(aArray1,aArray2,bEqual,lSort,bSort) class ArrayTools
 
 return(aUnique)
 
-/*/{Protheus.doc} MergeDeep
+/*{Protheus.doc} MergeDeep
     Realiza merge profundo de arrays.
     Quando a mesma posicao dos dois arrays possuir outro array, faz merge recursivo.
     Caso contrario, o valor do segundo array prevalece quando existir.
@@ -250,7 +250,7 @@ return(aUnique)
     @example
         aResult:=ArrayTools():MergeDeep({1,{"A"}},{2,{"B"}})
         // Resultado aproximado: {2,{"A","B"}}
-/*/
+*/
 static method MergeDeep(aArray1,aArray2,lClone) class ArrayTools
 
     local aResult as array
@@ -299,7 +299,7 @@ static method MergeDeep(aArray1,aArray2,lClone) class ArrayTools
 
 return(aResult)
 
-/*/{Protheus.doc} Zip
+/*{Protheus.doc} Zip
     Agrupa dois arrays por posicao.
 
     @type       Static Method
@@ -311,7 +311,7 @@ return(aResult)
     @example
         aResult:=ArrayTools():Zip({"A","B"},{1,2})
         // Resultado: {{"A",1},{"B",2}}
-/*/
+*/
 static method Zip(aArray1,aArray2,xDefault)class ArrayTools
 
     local aResult as array
@@ -340,15 +340,15 @@ static method Zip(aArray1,aArray2,xDefault)class ArrayTools
 
 return(aResult)
 
-/*/{Protheus.doc} Union
+/*{Protheus.doc} Union
     Retorna uniao entre dois arrays, sem duplicidade.
-/*/
+*/
 static method Union(aArray1,aArray2,bEqual) class ArrayTools
 return(ArrayTools():MergeUnique(aArray1,aArray2,bEqual,.F.,nil))
 
-/*/{Protheus.doc} Intersect
+/*{Protheus.doc} Intersect
     Retorna apenas itens existentes nos dois arrays.
-/*/
+*/
 static method Intersect(aArray1,aArray2,bEqual) class ArrayTools
 
     local aResult as array
@@ -369,9 +369,9 @@ static method Intersect(aArray1,aArray2,bEqual) class ArrayTools
 
 return(aResult)
 
-/*/{Protheus.doc} Diff
+/*{Protheus.doc} Diff
     Retorna itens existentes no primeiro array e ausentes no segundo.
-/*/
+*/
 static method Diff(aArray1,aArray2,bEqual) class ArrayTools
 
     local aResult as array
@@ -391,9 +391,9 @@ static method Diff(aArray1,aArray2,bEqual) class ArrayTools
 
 return(aResult)
 
-/*/{Protheus.doc} Clone
+/*{Protheus.doc} Clone
     Clona array recursivamente.
-/*/
+*/
 static method Clone(aArray) class ArrayTools
 
     local aCloneArray as array
@@ -414,16 +414,16 @@ static method Clone(aArray) class ArrayTools
 
 return(aCloneArray)
 
-/*/{Protheus.doc} Contains
+/*{Protheus.doc} Contains
     Verifica se um array contem determinado valor.
-/*/
+*/
 static method Contains(aArray,xValue,bEqual) class ArrayTools
 return(ArrayTools():IndexOf(aArray,xValue,bEqual)>0)
 
-/*/{Protheus.doc} IndexOf
+/*{Protheus.doc} IndexOf
     Retorna a posicao de um valor no array.
     Retorna 0 quando nao encontrar.
-/*/
+*/
 static method IndexOf(aArray,xValue,bEqual) class ArrayTools
 
     local lEqual as logical


### PR DESCRIPTION
Normalize documentation block markers in src/fw.webex/core/tools/fw.webex.array.tools.tlpp: replace occurrences of "/*/{Protheus.doc}" with "/* {Protheus.doc}" and change closing "/*/" to "*/" across the file. This corrects docblock syntax for Protheus/doc tooling and makes no functional changes to the ArrayTools implementation.